### PR TITLE
#25: 日本全国の感染者数の項目を追加

### DIFF
--- a/cron/csv_file.py
+++ b/cron/csv_file.py
@@ -19,6 +19,16 @@ class NHKPrefecturesCSV:
     CSV_PREFECTURE_CODE_NAME = "都道府県コード"
     CSV_NUM_NAME = "各地の感染者数_1日ごとの発表数"
 
+    # 列とそのデータ型
+    CSV_COLUMN_D_TYPES = {
+        CSV_DATE_COL_NAME: str,
+        CSV_PREFECTURE_CODE_NAME: str,
+        CSV_NUM_NAME: int
+    }
+
+    # 日本全国を指す都道府県コード(あくまで便宜上)
+    NATIONWIDE_PREFECTURE_CODE = "00"
+
     @classmethod
     def _fetch(cls):
         """公開されている感染者情報のCSVを取得する.
@@ -43,10 +53,37 @@ class NHKPrefecturesCSV:
         Returns
         -------
         pandas.DataFrame"""
+        # CSV情報からDataFrameを生成
         csv_data = [row.split(cls.FILE_SPLIT) for row in content.split(cls.FILE_NEWLINE)[:-1]]
         patients_df = pd.DataFrame(csv_data[1:], columns=csv_data[0])
 
-        return patients_df
+        # 必要な列のデータ型を修正
+        ret = patients_df.astype(cls.CSV_COLUMN_D_TYPES)
+
+        return ret
+
+    @classmethod
+    def _add_nationwide(cls, prefecture_df):
+        """都道府県コード'00'の、全国の感染者数がわかるレコードを追加する.
+
+        Parameters
+        ----------
+        prefecture_df: pandas.DataFrame
+            47都道府県の情報が格納されたデータフレーム
+
+        Returns
+        -------
+        pandas.DataFrame
+            47都道府県に加え、日本全国のその日毎の感染者数情報が格納されたデータフレーム"""
+        # 全国の感染者情報を保持したDataFrameを生成
+        nationwide_df = prefecture_df.groupby([cls.CSV_DATE_COL_NAME]).sum().reset_index(drop=False)
+        nationwide_df[cls.CSV_PREFECTURE_CODE_NAME] = cls.NATIONWIDE_PREFECTURE_CODE  # 便宜上のコード'00'
+        nationwide_df = nationwide_df.reindex(columns=cls.CSV_COLUMN_D_TYPES.keys())  # 列の順番を並び替え
+
+        # 都道府県毎の情報に、全国の情報を追加
+        ret = pd.concat([prefecture_df, nationwide_df]).reset_index(drop=True)
+
+        return ret
 
     @classmethod
     def gen_df(cls):
@@ -55,4 +92,8 @@ class NHKPrefecturesCSV:
         Returns
         -------
         pandas.DataFrame"""
-        return cls._format_patients_df(cls._fetch())
+        prefecture_df = cls._format_patients_df(cls._fetch())
+        # 都道府県毎の情報から、不必要な列情報を削除
+        prefecture_df = prefecture_df[cls.CSV_COLUMN_D_TYPES.keys()]
+
+        return cls._add_nationwide(prefecture_df)

--- a/cron/db.py
+++ b/cron/db.py
@@ -55,7 +55,7 @@ class PatientsModel(Base):
         for idx in range(len(df)):
             # 情報を生成
             publication_date = datetime.strptime(df.iloc[idx][NHKPrefecturesCSV.CSV_DATE_COL_NAME], "%Y/%m/%d")
-            num = df.iloc[idx][NHKPrefecturesCSV.CSV_NUM_NAME]
+            num = int(df.iloc[idx][NHKPrefecturesCSV.CSV_NUM_NAME])
             prefecture_code = df.iloc[idx][NHKPrefecturesCSV.CSV_PREFECTURE_CODE_NAME]
             # 1レコード分の情報生成
             table = PatientsModel()

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -18,7 +18,8 @@ def api_calendar(prefecture_code):
     ----------
     prefecture_code: 都道府県コード"""
 
-    if prefecture_code not in [f"{idx:02d}" for idx in range(1, 48)]:
+    # 全国 + 47都道府県 以外のコードが要求された場合は空を返却
+    if prefecture_code not in [f"{idx:02d}" for idx in range(0, 48)]:
         return jsonify([])
 
     records = PatientsModel.fetch_num(prefecture_code)
@@ -44,7 +45,9 @@ def api_prefectures():
     """地域選択用セレクトボックスにて使用する地域情報を返却するAPI"""
 
     return jsonify([
-        {"prefecture_name": "東京都", "prefecture_code": "13"},
+        # 日本全国を指す都道府県コードを便宜上'00'としている
+        {"prefecture_name": "全国", "prefecture_code": "00"},
+        # 以下、47都道府県
         {"prefecture_name": "北海道", "prefecture_code": "01"},
         {"prefecture_name": "青森県", "prefecture_code": "02"},
         {"prefecture_name": "岩手県", "prefecture_code": "03"},
@@ -57,6 +60,7 @@ def api_prefectures():
         {"prefecture_name": "群馬県", "prefecture_code": "10"},
         {"prefecture_name": "埼玉県", "prefecture_code": "11"},
         {"prefecture_name": "千葉県", "prefecture_code": "12"},
+        {"prefecture_name": "東京都", "prefecture_code": "13"},
         {"prefecture_name": "神奈川県", "prefecture_code": "14"},
         {"prefecture_name": "新潟県", "prefecture_code": "15"},
         {"prefecture_name": "富山県", "prefecture_code": "16"},

--- a/flask_app/static/api.js
+++ b/flask_app/static/api.js
@@ -3,8 +3,8 @@ const calendarApp = new Vue({
     // jinja2のデリミタ {{}} と競合するため、デリミタを変更
     delimiters: ["[[", "]]"],
     data: {
-        // デフォルトは東京
-        PrefectureCode: "13",
+        // デフォルトは全国
+        PrefectureCode: "00",
         items: [],
         options: []
     },


### PR DESCRIPTION
- カレンダーに日本全国のその日毎の感染者数の項目を追加
- ページ遷移時のデフォルトのカレンダーを東京から日本全国に変更
